### PR TITLE
Remove unneeded config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,11 +18,8 @@ defmodule PinsterPhoenix.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {PinsterPhoenix, []},
-     applications: apps(Mix.env)]
+     applications: apps]
   end
-
-  def apps(:test), do: [:hound | apps]
-  def apps(_), do: apps
 
   def apps do
     [:phoenix, :phoenix_html, :cowboy, :logger, :gettext, :phoenix_ecto, :postgrex]

--- a/mix.exs
+++ b/mix.exs
@@ -18,11 +18,8 @@ defmodule PinsterPhoenix.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {PinsterPhoenix, []},
-     applications: apps]
-  end
-
-  def apps do
-    [:phoenix, :phoenix_html, :cowboy, :logger, :gettext, :phoenix_ecto, :postgrex]
+     applications: [:phoenix, :phoenix_html, :cowboy, :logger, :gettext,
+                    :phoenix_ecto, :postgrex]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
Hound is started in test/test_helper.exs so no need to have a special set of
apps in our mix config.
